### PR TITLE
Improved comment parsing

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -83,7 +83,6 @@ pub enum SymbolType {
     Words(Vec<String>),
     Integer(String),
     Floating(String),
-    Comment,
     Listen,
     Divide,
     True,


### PR DESCRIPTION
Ended up ripping out the comment symbol entirely in favour of regex-style stripping of them at the beginning.