### PR TITLE
Upgrade all the actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,66 +17,55 @@ jobs:
           - beta
           - nightly
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           profile: minimal
           toolchain: ${{ matrix.rust }}
-          override: true
           components: clippy, rustfmt
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - name: Check formatting
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: -- --check
+        run: cargo fmt -- --check
         if: matrix.rust == 'stable'
       - name: Clippy
         run: cargo clippy -- -W clippy::all
         if: matrix.rust == 'stable'
       - name: Build and test
-        uses: actions-rs/cargo@v1
+        run: cargo test
         env:
           RUST_MIN_STACK: 8388608
-        with:
-          command: test
 
   minimal-versions:
     name: minimal versions check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           profile: minimal
           toolchain: nightly
-          override: true
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - name: Remove lock
         run: rm Cargo.lock
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: -Z minimal-versions
+      - run: cargo build -Z minimal-versions
 
   web:
     name: web build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           profile: minimal
           toolchain: stable
-          override: true
           target: wasm32-unknown-unknown
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - name: Install trunk
         run: wget -qO- https://github.com/thedodd/trunk/releases/download/${VERSION}/trunk-x86_64-unknown-linux-gnu.tar.gz | tar -xzf-
         env:
@@ -89,16 +78,16 @@ jobs:
     needs: [web, test, minimal-versions]
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           profile: minimal
           toolchain: stable
           override: true
           target: wasm32-unknown-unknown
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - name: Install trunk
         run: wget -qO- https://github.com/thedodd/trunk/releases/download/${VERSION}/trunk-x86_64-unknown-linux-gnu.tar.gz | tar -xzf-
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ jobs:
           submodules: true
       - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
           components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2
@@ -46,7 +45,6 @@ jobs:
           submodules: true
       - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: nightly
       - uses: Swatinem/rust-cache@v2
       - name: Remove lock
@@ -62,7 +60,6 @@ jobs:
           submodules: true
       - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: stable
           target: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
@@ -83,7 +80,6 @@ jobs:
           submodules: true
       - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: stable
           override: true
           target: wasm32-unknown-unknown


### PR DESCRIPTION
Mostly to fix https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/